### PR TITLE
Add Erlang and Elixir providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All changes to the images, whether it's a new image or an update will be added h
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
-## 2017-08-21
+## Unreleased
 ### Added
 - New [Erlang](erlang/) integration with initial versions: [19.3](erlang/19.3) and [20.0](erlang/20.0)
 - New [Elixir](elixir/) integration with initial versions: [1.2.6](elixir/1.2.6), [1.3.4](elixir/1.3.4) and [1.4.5](elixir/1.4.5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All changes to the images, whether it's a new image or an update will be added h
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## 2017-08-21
+### Added
+- New [Erlang](erlang/) integration with initial versions: [19.3](erlang/19.3) and [20.0](erlang/20.0)
+- New [Elixir](elixir/) integration with initial versions: [1.2.6](elixir/1.2.6), [1.3.4](elixir/1.3.4) and [1.4.5](elixir/1.4.5)
+
 ## 2017-06-28
 ### Added
 - Add [Ruby](ruby/) versions: [2.3.4](ruby/2.3.4), [2.4.0](ruby/2.4.0) and [2.4.1](ruby/2.4.1).

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -72,9 +72,17 @@ RUN ./ruby.sh
 COPY components/python.sh .
 RUN ./python.sh
 
+# Erlang
+COPY components/erlang.sh .
+RUN ./erlang.sh
+
+# Elixir
+COPY components/elixir.sh .
+RUN ./elixir.sh
+
 # Cleanup
 USER root
-RUN rm -f nodejs.sh ruby.sh python.sh
+RUN rm -f nodejs.sh ruby.sh python.sh erlang.sh elixir.sh
 
 # Pipeline command execution environment
 USER dockbit

--- a/base/components/elixir.sh
+++ b/base/components/elixir.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+export KIEX_VERSION=master
+export ELIXIR_VERSION=1.4.5
+
+# Install Kiex and execute initial setup
+curl -sSL https://raw.githubusercontent.com/taylor/kiex/${KIEX_VERSION}/install | bash -s
+echo 'test -s "$HOME/.kiex/scripts/kiex" && source "$HOME/.kiex/scripts/kiex"' >> $HOME/.bash_profile
+
+# Load Erlang
+source $HOME/.bash_profile && \
+ERLANG_VERION=`kerl list installations | head -n 1 | cut -d" " -f1` && \
+source $HOME/.kerl/${ERLANG_VERION}/activate
+
+# Build Elixir and set default version
+kiex install 1.2.6 && \
+kiex install 1.3.4 && \
+kiex install $ELIXIR_VERSION && kiex default $ELIXIR_VERSION
+
+# Install Hex
+kiex use $ELIXIR_VERSION && mix local.hex --force
+kiex use 1.2.6 && mix local.hex --force
+kiex use 1.3.4 && mix local.hex --force
+
+# Install rebar3
+mix local.rebar --force

--- a/base/components/erlang.sh
+++ b/base/components/erlang.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+export KERL_VERSION=1.5.1
+export ERLANG_VERSION=20.0
+
+# Download kerl
+curl -o $HOME/.local/bin/kerl https://raw.githubusercontent.com/kerl/kerl/${KERL_VERSION}/kerl && \
+chmod 755 $HOME/.local/bin/kerl
+
+# Download rebar
+curl -o $HOME/.local/bin/rebar3 https://s3.amazonaws.com/rebar3/rebar3 && \
+chmod 755 $HOME/.local/bin/rebar3 && \
+ln -sf $HOME/.local/bin/rebar3 $HOME/.local/bin/rebar
+
+cat << EOF > $HOME/.kerlrc
+KERL_CONFIGURE_OPTIONS="--without-javac --without-wx"
+EOF
+
+# Build Erlang
+source $HOME/.bash_profile && \
+kerl update releases && \
+kerl build $ERLANG_VERSION $ERLANG_VERSION && \
+kerl build 19.3 19.3
+
+# Install Erlang
+kerl install $ERLANG_VERSION $HOME/.kerl/$ERLANG_VERSION && \
+kerl install 19.3 $HOME/.kerl/19.3

--- a/base/components/libraries.sh
+++ b/base/components/libraries.sh
@@ -33,7 +33,8 @@ apt-get -qq update && apt-get -qq install -y --no-install-recommends \
   libwebp-dev \
   libxml2-dev \
   libxslt-dev \
-  libyaml-dev
+  libyaml-dev \
+  unixodbc-dev
 
 # Cleanup
 rm -rf /var/lib/apt/lists/*

--- a/base/templates/Dockerfile.template
+++ b/base/templates/Dockerfile.template
@@ -72,9 +72,17 @@ RUN ./ruby.sh
 COPY components/python.sh .
 RUN ./python.sh
 
+# Erlang
+COPY components/erlang.sh .
+RUN ./erlang.sh
+
+# Elixir
+COPY components/elixir.sh .
+RUN ./elixir.sh
+
 # Cleanup
 USER root
-RUN rm -f nodejs.sh ruby.sh python.sh
+RUN rm -f nodejs.sh ruby.sh python.sh erlang.sh elixir.sh
 
 # Pipeline command execution environment
 USER dockbit

--- a/elixir/1.2.6/Dockerfile
+++ b/elixir/1.2.6/Dockerfile
@@ -1,0 +1,6 @@
+FROM dockbit/erlang:20.0
+MAINTAINER The Dockbit Team "team@dockbit.com"
+
+# Execution environment
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/elixir/1.2.6/build.sh
+++ b/elixir/1.2.6/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "#########################################"
+echo "Building elixir version 1.2.6"
+echo "#########################################"
+docker build -t dockbit/elixir:1.2.6 .
+

--- a/elixir/1.2.6/docker-entrypoint.sh
+++ b/elixir/1.2.6/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+source /bin/dockbit_bootstrap.sh
+
+# Load Erlang
+if [ -f .erlang-version ]; then
+  ERLANG_VERSION=`cat .erlang-version`
+else
+  ERLANG_VERSION=`kerl list installations | head -n 1 | cut -d" " -f1`
+fi
+. $HOME/.kerl/$ERLANG_VERSION/activate
+
+if [ -f .elixir-version ]; then
+  ELIXIR_VERSION=`cat .elixir-version`
+else
+  ELIXIR_VERSION="1.2.6"
+fi
+kiex use $ELIXIR_VERSION
+
+if [ -f mix.lock ]; then
+  hacher get -k hex -f mix.lock /
+  run mix deps.get
+  hacher set -k hex -f mix.lock $HOME/.hex
+fi
+
+run_user

--- a/elixir/1.3.4/Dockerfile
+++ b/elixir/1.3.4/Dockerfile
@@ -1,0 +1,6 @@
+FROM dockbit/erlang:20.0
+MAINTAINER The Dockbit Team "team@dockbit.com"
+
+# Execution environment
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/elixir/1.3.4/build.sh
+++ b/elixir/1.3.4/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "#########################################"
+echo "Building elixir version 1.3.4"
+echo "#########################################"
+docker build -t dockbit/elixir:1.3.4 .
+

--- a/elixir/1.3.4/docker-entrypoint.sh
+++ b/elixir/1.3.4/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+source /bin/dockbit_bootstrap.sh
+
+# Load Erlang
+if [ -f .erlang-version ]; then
+  ERLANG_VERSION=`cat .erlang-version`
+else
+  ERLANG_VERSION=`kerl list installations | head -n 1 | cut -d" " -f1`
+fi
+. $HOME/.kerl/$ERLANG_VERSION/activate
+
+if [ -f .elixir-version ]; then
+  ELIXIR_VERSION=`cat .elixir-version`
+else
+  ELIXIR_VERSION="1.3.4"
+fi
+kiex use $ELIXIR_VERSION
+
+if [ -f mix.lock ]; then
+  hacher get -k hex -f mix.lock /
+  run mix deps.get
+  hacher set -k hex -f mix.lock $HOME/.hex
+fi
+
+run_user

--- a/elixir/1.4.5/Dockerfile
+++ b/elixir/1.4.5/Dockerfile
@@ -1,0 +1,6 @@
+FROM dockbit/erlang:20.0
+MAINTAINER The Dockbit Team "team@dockbit.com"
+
+# Execution environment
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/elixir/1.4.5/build.sh
+++ b/elixir/1.4.5/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "#########################################"
+echo "Building elixir version 1.4.5"
+echo "#########################################"
+docker build -t dockbit/elixir:1.4.5 .
+

--- a/elixir/1.4.5/docker-entrypoint.sh
+++ b/elixir/1.4.5/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+source /bin/dockbit_bootstrap.sh
+
+# Load Erlang
+if [ -f .erlang-version ]; then
+  ERLANG_VERSION=`cat .erlang-version`
+else
+  ERLANG_VERSION=`kerl list installations | head -n 1 | cut -d" " -f1`
+fi
+. $HOME/.kerl/$ERLANG_VERSION/activate
+
+if [ -f .elixir-version ]; then
+  ELIXIR_VERSION=`cat .elixir-version`
+else
+  ELIXIR_VERSION="1.4.5"
+fi
+kiex use $ELIXIR_VERSION
+
+if [ -f mix.lock ]; then
+  hacher get -k hex -f mix.lock /
+  run mix deps.get
+  hacher set -k hex -f mix.lock $HOME/.hex
+fi
+
+run_user

--- a/elixir/templates/Dockerfile.template
+++ b/elixir/templates/Dockerfile.template
@@ -1,0 +1,6 @@
+FROM %%ORG%%/erlang:20.0
+MAINTAINER The Dockbit Team "team@dockbit.com"
+
+# Execution environment
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/elixir/templates/build.sh.template
+++ b/elixir/templates/build.sh.template
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "#########################################"
+echo "Building %%IMAGE%% version %%VERSION%%"
+echo "#########################################"
+docker build -t %%ORG%%/%%IMAGE%%:%%VERSION%% .
+

--- a/elixir/templates/docker-entrypoint.sh.template
+++ b/elixir/templates/docker-entrypoint.sh.template
@@ -1,0 +1,25 @@
+#!/bin/bash
+source /bin/dockbit_bootstrap.sh
+
+# Load Erlang
+if [ -f .erlang-version ]; then
+  ERLANG_VERSION=`cat .erlang-version`
+else
+  ERLANG_VERSION=`kerl list installations | head -n 1 | cut -d" " -f1`
+fi
+. $HOME/.kerl/$ERLANG_VERSION/activate
+
+if [ -f .elixir-version ]; then
+  ELIXIR_VERSION=`cat .elixir-version`
+else
+  ELIXIR_VERSION="%%VERSION%%"
+fi
+kiex use $ELIXIR_VERSION
+
+if [ -f mix.lock ]; then
+  hacher get -k hex -f mix.lock /
+  run mix deps.get
+  hacher set -k hex -f mix.lock $HOME/.hex
+fi
+
+run_user

--- a/elixir/versions.list
+++ b/elixir/versions.list
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# List of supported Elixir versions
+#
+
+image=elixir
+
+versions=(
+  1.2.6
+  1.3.4
+  1.4.5:latest
+)

--- a/erlang/19.3/Dockerfile
+++ b/erlang/19.3/Dockerfile
@@ -1,0 +1,6 @@
+FROM dockbit/base:latest
+MAINTAINER The Dockbit Team "team@dockbit.com"
+
+# Execution environment
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/erlang/19.3/build.sh
+++ b/erlang/19.3/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "#########################################"
+echo "Building erlang version 19.3"
+echo "#########################################"
+docker build -t dockbit/erlang:19.3 .
+

--- a/erlang/19.3/docker-entrypoint.sh
+++ b/erlang/19.3/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+source /bin/dockbit_bootstrap.sh
+
+if [ -f .erlang-version ]; then
+  ERLANG_VERSION=`cat .erlang-version`
+else
+  ERLANG_VERSION="19.3"
+fi
+. $HOME/.kerl/$ERLANG_VERSION/activate
+
+run_user

--- a/erlang/20.0/Dockerfile
+++ b/erlang/20.0/Dockerfile
@@ -1,0 +1,6 @@
+FROM dockbit/base:latest
+MAINTAINER The Dockbit Team "team@dockbit.com"
+
+# Execution environment
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/erlang/20.0/build.sh
+++ b/erlang/20.0/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "#########################################"
+echo "Building erlang version 20.0"
+echo "#########################################"
+docker build -t dockbit/erlang:20.0 .
+

--- a/erlang/20.0/docker-entrypoint.sh
+++ b/erlang/20.0/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+source /bin/dockbit_bootstrap.sh
+
+if [ -f .erlang-version ]; then
+  ERLANG_VERSION=`cat .erlang-version`
+else
+  ERLANG_VERSION="20.0"
+fi
+. $HOME/.kerl/$ERLANG_VERSION/activate
+
+run_user

--- a/erlang/templates/Dockerfile.template
+++ b/erlang/templates/Dockerfile.template
@@ -1,0 +1,6 @@
+FROM %%ORG%%/base:%%TAG%%
+MAINTAINER The Dockbit Team "team@dockbit.com"
+
+# Execution environment
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/erlang/templates/build.sh.template
+++ b/erlang/templates/build.sh.template
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "#########################################"
+echo "Building %%IMAGE%% version %%VERSION%%"
+echo "#########################################"
+docker build -t %%ORG%%/%%IMAGE%%:%%VERSION%% .
+

--- a/erlang/templates/docker-entrypoint.sh.template
+++ b/erlang/templates/docker-entrypoint.sh.template
@@ -1,0 +1,11 @@
+#!/bin/bash
+source /bin/dockbit_bootstrap.sh
+
+if [ -f .erlang-version ]; then
+  ERLANG_VERSION=`cat .erlang-version`
+else
+  ERLANG_VERSION="%%VERSION%%"
+fi
+. $HOME/.kerl/$ERLANG_VERSION/activate
+
+run_user

--- a/erlang/versions.list
+++ b/erlang/versions.list
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# List of supported Erlang versions
+#
+
+image=erlang
+
+versions=(
+  19.3
+  20.0:latest
+)


### PR DESCRIPTION
This PR adds support for:

- Erlang versions 19.3 and 20.0 (default), managed by [kerl](https://github.com/kerl/kerl)
- Elixir versions 1.2.6, 1.3.4, and 1.4.5 (default), managed by [kiex](https://github.com/taylor/kiex)
